### PR TITLE
Release phonetics-rs 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,26 @@ prior C-extension gem's `3.x`).
 
 ## [Unreleased]
 
-### Added
+## [0.3.0] — 2026-05-12 (`phonetics-rs` only)
+
+### Added — Rust core (`phonetics-rs`)
 - `Trie::words_approximately_starting_at` (feature `transcriptions`):
   budgeted DFS through the transcription trie that allows per-
   character phonetic substitution while staying inside a caller-
   supplied cost budget. Designed for use by the
   [madgab](https://github.com/JackDanger/madgab) Mad Gab generator.
 
-### Changed
-- Python wheel: pyo3 0.22 → 0.24 (no behaviour change; quieter
-  deprecation warnings on Python 3.13).
+### Changed — Python wheel (internal only)
+- pyo3 0.22 → 0.24. No behaviour change; quieter deprecation warnings
+  on Python 3.13. The published `phonetics-ipa` wheel version stays
+  at 0.2.0 because no Python-visible surface changed.
+
+### Notes
+- The Ruby gem and Python wheel don't yet expose the `transcriptions`
+  module to their host languages, so this release ships only on
+  crates.io. The unified release workflow runs all three registry
+  jobs on the `v0.3.0` tag, but the PyPI / RubyGems uploads no-op
+  via `skip-existing` because their versions are unchanged.
 
 ## [0.2.0] — 2026-05-12
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "phonetics-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 # available.
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/JackDanger/phonetics"


### PR DESCRIPTION
Bumps the Rust crate to 0.3.0 to ship `Trie::words_approximately_starting_at` on crates.io.

Once merged, tag `v0.3.0` on the resulting main commit to trigger the publish workflow.

Python wheel and Ruby gem versions stay put — they don't expose the transcriptions API yet, so there's nothing new for those registries. The publish workflow's `skip-existing` handling makes the no-op uploads safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)