### PR TITLE
Fix cargo publish step that silently no-ops on first run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,17 +22,28 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: cargo publish
         working-directory: rust/phonetics
+        # `pipefail` is essential: cargo's exit code must survive the
+        # pipe to `tee`. Without it, `cargo failing | tee` exits 0 and
+        # the job is silently marked green even when nothing was
+        # actually uploaded.
+        shell: bash -eo pipefail {0}
         run: |
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
             echo "Pre-release tag — running cargo publish --dry-run."
             cargo publish --dry-run
           else
-            # cargo publish doesn't have a --skip-existing flag. The
-            # "already published" failure mode prints a specific
-            # message; grep for it to make retry runs idempotent
-            # without swallowing real errors.
-            if ! cargo publish --token "${CARGO_REGISTRY_TOKEN}" 2>&1 | tee publish.log; then
-              if grep -q "already.*uploaded\|crate version.*is already uploaded" publish.log; then
+            # Write the publish log to /tmp so cargo doesn't see it as
+            # uncommitted work in the crate directory and refuse to
+            # publish ("files in the working directory contain changes
+            # that were not yet committed into git").
+            LOG=$(mktemp)
+            if ! cargo publish --token "${CARGO_REGISTRY_TOKEN}" 2>&1 | tee "$LOG"; then
+              # cargo's "already published" wording has changed across
+              # versions ("already uploaded", "already exists on
+              # crates.io index"). Match both so rerun-after-success
+              # treats the failure as idempotent without swallowing
+              # genuine errors.
+              if grep -qE "already.*uploaded|already exists on crates\.io" "$LOG"; then
                 echo "::warning::version already on crates.io — treating as success"
                 exit 0
               fi


### PR DESCRIPTION
The v0.3.0 publish workflow run reported success on the crates.io job but **never actually uploaded the crate**. Two compounding bugs:

1. `cargo publish 2>&1 | tee publish.log` writes `publish.log` inside the crate dir. cargo then refuses to publish ("files in the working directory contain changes that were not yet committed").
2. The step's shell is `bash -e` without `pipefail`, so cargo's failure exit code is masked by tee's success and the job goes green.

Fix: log to `$(mktemp)` outside the crate dir, set `bash -eo pipefail`, and broaden the idempotency-grep regex to match modern cargo's "already exists on crates.io" wording.

Once merged, the v0.3.0 tag will be re-pointed at the new main HEAD to retrigger the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)