### PR TITLE
Make preferred_ipa deterministic and corpus-label aware (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ prior C-extension gem's `3.x`).
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-05-12 (`phonetics-rs` only)
+
+### Fixed
+- `Corpus::preferred_ipa` no longer non-deterministically returns
+  `cmu2` (or `wikipron2`, etc.) when the canonical `cmu` entry is
+  also present. The earlier implementation used `source.contains(...)`,
+  which matches indexed variants too; combined with random HashMap
+  iteration order this made the result of `preferred_ipa` depend on
+  the process-wide hash seed. Now each preference is tried as an
+  exact match first and only falls through to prefix matching when
+  no exact match exists.
+
+### Changed
+- `SOURCE_PREFERENCE` extended with the new corpus labels
+  (`misaki_gold`, `misaki_silver`, `wikipron`) while keeping the old
+  labels (`phonemicchart`, `wiktionary`) for backward compatibility.
+  Existing corpora resolve identically; new corpora built with the
+  fused-source pipeline (see madgab `corpus/build.py`) get clean
+  resolution out of the box.
+
 ## [0.3.0] — 2026-05-12 (`phonetics-rs` only)
 
 ### Added — Rust core (`phonetics-rs`)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "phonetics-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 # available.
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/JackDanger/phonetics"

--- a/rust/phonetics/src/transcriptions.rs
+++ b/rust/phonetics/src/transcriptions.rs
@@ -209,15 +209,40 @@ pub struct Corpus {
 }
 
 /// Source-preference order used by [`Corpus::preferred_ipa`]. The
-/// first source whose name *contains* one of these substrings wins.
+/// first source whose label exactly matches one of these wins; if no
+/// exact match exists for any preference, we fall back to a
+/// prefix-match pass (so a corpus carrying `cmu`, `cmu2`, `cmu3`
+/// still resolves cleanly when the canonical `cmu` entry happens to
+/// be absent).
 ///
-/// CMU is professionally curated and canonical for American English;
-/// the Wiktionary corpus has known data-quality issues (e.g. "pie"
-/// transcribed as `piaɪi`) and is used as fallback. This differs
-/// from the Ruby gem's historical order, which preferred Wiktionary;
-/// for downstream search the more reliable transcription matters
-/// more than the more permissive one.
-const SOURCE_PREFERENCE: &[&str] = &["cmu", "phonemicchart", "wiktionary"];
+/// The order below reflects empirical reliability for American
+/// English Mad Gab generation:
+///
+/// * `cmu` — Carnegie Mellon Pronouncing Dictionary, ARPABET-derived
+///   IPA. Most reliable broad transcription; function words come
+///   through in their weak (contextual) form, which is what speakers
+///   actually produce.
+/// * `misaki_gold` — vetted near-IPA from the Kokoro TTS project.
+///   Narrow vowel distinctions but tends to give citation/strong
+///   forms for function words (e.g. `a` → `eɪ`).
+/// * `misaki_silver` — Misaki's silver tier; noisier than gold but
+///   still useful gap-fill.
+/// * `phonemicchart` / `wiktionary` — legacy labels from the older
+///   madgab corpus; retained for backward compatibility.
+/// * `wikipron` — broad scrape from Wiktionary via WikiPron. Captures
+///   pronunciation variants; quality varies.
+///
+/// Earlier releases used substring matching here, which caused
+/// non-deterministic resolution between `cmu` and `cmu2` because the
+/// underlying entry map iterates in random hash order.
+const SOURCE_PREFERENCE: &[&str] = &[
+    "cmu",
+    "misaki_gold",
+    "misaki_silver",
+    "phonemicchart",
+    "wiktionary",
+    "wikipron",
+];
 
 impl Corpus {
     /// Parse the JSON corpus and build both forward and reverse
@@ -264,13 +289,23 @@ impl Corpus {
             .unwrap_or(&[])
     }
 
-    /// The "best" IPA transcription for `word`: the first source
-    /// whose label matches the [`SOURCE_PREFERENCE`] order, falling
-    /// back to whatever appears first in the corpus.
+    /// The "best" IPA transcription for `word`: the first source whose
+    /// label matches the [`SOURCE_PREFERENCE`] order, falling back to
+    /// whatever appears first in the corpus.
+    ///
+    /// Walks each preference in order, trying exact label match first
+    /// (so `cmu` beats `cmu2`) and then prefix match (so when only
+    /// `cmu2` exists we still resolve under the `cmu` preference
+    /// rather than fall through to a less-preferred source). Exact
+    /// matching is what makes resolution deterministic in the
+    /// presence of indexed-variant labels.
     pub fn preferred_ipa(&self, word: &str) -> Option<&str> {
         let prs = self.pronunciations(word);
         for pref in SOURCE_PREFERENCE {
-            if let Some(p) = prs.iter().find(|p| p.source.contains(pref)) {
+            if let Some(p) = prs.iter().find(|p| p.source == *pref) {
+                return Some(&p.ipa);
+            }
+            if let Some(p) = prs.iter().find(|p| p.source.starts_with(pref)) {
                 return Some(&p.ipa);
             }
         }
@@ -448,5 +483,48 @@ mod tests {
             .collect();
         assert!(words.contains(&"cat"));
         assert!(words.contains(&"cats"));
+    }
+
+    // Regression: when a word carries multiple CMU variants
+    // (`cmu`, `cmu2`, `cmu3`), `preferred_ipa` must return the
+    // primary `cmu` entry. Earlier substring-matching logic could
+    // return `cmu2` because HashMap iteration order is randomized.
+    #[test]
+    fn preferred_ipa_picks_exact_over_indexed_variant() {
+        let json = r#"{
+            "just": {
+                "rarity": 45.0,
+                "ipa": {
+                    "cmu2":        "dʒɪst",
+                    "cmu":         "dʒˈʌst",
+                    "misaki_gold": "dʒˈʌst",
+                    "wikipron":    "dʒʌst"
+                }
+            }
+        }"#;
+        // Run a few times — if the bug returned, HashMap reshuffling
+        // would surface non-determinism in at least one iteration.
+        for _ in 0..32 {
+            let c = Corpus::from_json(json, None).unwrap();
+            assert_eq!(c.preferred_ipa("just"), Some("dʒˈʌst"));
+        }
+    }
+
+    // Prefix-match fallback: when no exact `cmu` entry exists, the
+    // search should still find `cmu2` rather than skip the whole
+    // family and fall through to a later preference (or to the
+    // arbitrary HashMap-first entry).
+    #[test]
+    fn preferred_ipa_falls_back_to_prefix_match() {
+        let json = r#"{
+            "ghost": {
+                "rarity": 5000.0,
+                "ipa": { "cmu2": "ɡoʊst", "wikipron": "ɡəʊst" }
+            }
+        }"#;
+        let c = Corpus::from_json(json, None).unwrap();
+        // No exact `cmu`, no `misaki_gold`, no `misaki_silver` —
+        // falls through to prefix match, which finds `cmu2`.
+        assert_eq!(c.preferred_ipa("ghost"), Some("ɡoʊst"));
     }
 }


### PR DESCRIPTION
## Why

Building a new fused English IPA corpus for [madgab](https://github.com/JackDanger/madgab) (combining Misaki gold/silver, CMUdict, WikiPron) exposed two problems in `Corpus::preferred_ipa`:

1. **Non-determinism.** The substring match `p.source.contains("cmu")` treats `cmu2`, `cmu3` as equally valid CMU hits. Combined with the randomized HashMap iteration that backs the per-word source list, the same corpus could return different "preferred" IPAs across runs depending on the process hash seed.

2. **Unaware of new sources.** The preference list `["cmu", "phonemicchart", "wiktionary"]` knew nothing about `misaki_gold`, `misaki_silver`, or `wikipron`. Words covered only by those sources fell through to the HashMap-arbitrary fallback.

## What

- Two-tier match per preference: exact label first, then prefix. Only after both fail does the loop advance.
- `SOURCE_PREFERENCE` extended with the new labels while keeping the legacy ones.
- Two regression tests: one that hammers the cmu/cmu2 ordering (32 runs to catch any HashMap reshuffling), one that exercises the prefix-fallback when only an indexed variant exists.

Existing corpora resolve identically — the new logic only changes behaviour for entries with multiple variants under the same source family, which the old corpus didn't have in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)